### PR TITLE
wip

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -5693,9 +5693,9 @@ flush-write-stream@^1.0.0:
     readable-stream "^2.3.6"
 
 follow-redirects@^1.0.0:
-  version "1.14.8"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.8.tgz#016996fb9a11a100566398b1c6839337d7bfa8fc"
-  integrity sha512-1x0S9UVJHsQprFcEC/qnNzBLcIxsjAV905f/UkQxbclCsoTWlacCNOpQa/anodLl2uaEKFhfWOvM2Qg77+15zA==
+  version "1.15.1"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.1.tgz#0ca6a452306c9b276e4d3127483e29575e207ad5"
+  integrity sha512-yLAMQs+k0b2m7cVxpS1VKJVvoz7SS9Td1zss3XRwXj+ZDH00RJgnuLx7E44wx02kQLrdM3aOOy+FpzS7+8OizA==
 
 for-in@^0.1.3:
   version "0.1.8"


### PR DESCRIPTION
```
 ~/repos/misc/jaeger/jaeger-ui/packages/jaeger-ui (sort-asset-manifest) $ yarn build
yarn run v1.22.19
$ REACT_APP_VSN_STATE=$(../../scripts/get-tracking-version.js) react-app-rewired build
Creating an optimized production build...
Browserslist: caniuse-lite is outdated. Please run next command `yarn upgrade caniuse-lite browserslist`
Browserslist: caniuse-lite is outdated. Please run next command `yarn upgrade caniuse-lite browserslist`
Browserslist: caniuse-lite is outdated. Please run next command `yarn upgrade caniuse-lite browserslist`
Browserslist: caniuse-lite is outdated. Please run next command `yarn upgrade caniuse-lite browserslist`
Browserslist: caniuse-lite is outdated. Please run next command `yarn upgrade caniuse-lite browserslist`
Browserslist: caniuse-lite is outdated. Please run next command `yarn upgrade caniuse-lite browserslist`
Browserslist: caniuse-lite is outdated. Please run next command `yarn upgrade caniuse-lite browserslist`
Browserslist: caniuse-lite is outdated. Please run next command `yarn upgrade caniuse-lite browserslist`
sort: main.js > main.css
sort: main.js.map > main.js
sort: static/css/1.a38ed525.chunk.css > main.js.map
sort: static/js/1.591b087f.chunk.js > static/css/1.a38ed525.chunk.css
sort: static/js/1.591b087f.chunk.js.map > static/js/1.591b087f.chunk.js
sort: runtime~main.js < static/js/1.591b087f.chunk.js.map
sort: runtime~main.js < static/css/1.a38ed525.chunk.css
sort: runtime~main.js > main.js
sort: runtime~main.js > main.js.map
sort: runtime~main.js.map > runtime~main.js
sort: runtime~main.js.map < static/js/1.591b087f.chunk.js
sort: runtime~main.js.map < static/css/1.a38ed525.chunk.css
sort: static/media/jaeger-logo.svg > runtime~main.js.map
sort: static/media/jaeger-logo.svg > static/js/1.591b087f.chunk.js
sort: static/media/jaeger-logo.svg > static/js/1.591b087f.chunk.js.map
sort: static/media/monitor.png > runtime~main.js.map
sort: static/media/monitor.png > static/js/1.591b087f.chunk.js.map
sort: static/media/monitor.png > static/media/jaeger-logo.svg
sort: static/css/1.a38ed525.chunk.css.map > static/css/1.a38ed525.chunk.css
sort: static/css/1.a38ed525.chunk.css.map < static/media/jaeger-logo.svg
sort: static/css/1.a38ed525.chunk.css.map < static/js/1.591b087f.chunk.js.map
sort: static/css/1.a38ed525.chunk.css.map < static/js/1.591b087f.chunk.js
sort: static/css/main.c80691aa.chunk.css.map > static/css/1.a38ed525.chunk.css
sort: static/css/main.c80691aa.chunk.css.map < static/js/1.591b087f.chunk.js.map
sort: static/css/main.c80691aa.chunk.css.map < static/js/1.591b087f.chunk.js
sort: static/css/main.c80691aa.chunk.css.map > static/css/1.a38ed525.chunk.css.map
sort: index.html < static/css/1.a38ed525.chunk.css.map
sort: index.html < runtime~main.js
sort: index.html < main.js
sort: index.html < main.css
sort: precache-manifest.354025eed03d63a1a55f874c4d415373.js < static/css/1.a38ed525.chunk.css
sort: precache-manifest.354025eed03d63a1a55f874c4d415373.js > main.js.map
sort: precache-manifest.354025eed03d63a1a55f874c4d415373.js < runtime~main.js.map
sort: precache-manifest.354025eed03d63a1a55f874c4d415373.js < runtime~main.js
sort: service-worker.js < static/css/1.a38ed525.chunk.css
sort: service-worker.js > main.js.map
sort: service-worker.js > runtime~main.js
sort: service-worker.js > runtime~main.js.map
{
  "index.html": "./index.html",
  "main.css": "./static/css/main.c80691aa.chunk.css",
  "main.js": "./static/js/main.375d1bb4.chunk.js",
  "main.js.map": "./static/js/main.375d1bb4.chunk.js.map",
  "precache-manifest.354025eed03d63a1a55f874c4d415373.js": "./precache-manifest.354025eed03d63a1a55f874c4d415373.js",
  "runtime~main.js": "./static/js/runtime~main.4a686d48.js",
  "runtime~main.js.map": "./static/js/runtime~main.4a686d48.js.map",
  "service-worker.js": "./service-worker.js",
  "static/css/1.a38ed525.chunk.css": "./static/css/1.a38ed525.chunk.css",
  "static/css/1.a38ed525.chunk.css.map": "./static/css/1.a38ed525.chunk.css.map",
  "static/css/main.c80691aa.chunk.css.map": "./static/css/main.c80691aa.chunk.css.map",
  "static/js/1.591b087f.chunk.js": "./static/js/1.591b087f.chunk.js",
  "static/js/1.591b087f.chunk.js.map": "./static/js/1.591b087f.chunk.js.map",
  "static/media/jaeger-logo.svg": "./static/media/jaeger-logo.a7093b12.svg",
  "static/media/monitor.png": "./static/media/monitor.c9164c96.png"
}
Compiled successfully.

File sizes after gzip:

  694.07 KB  build/static/js/1.591b087f.chunk.js
  661.83 KB  build/static/js/main.375d1bb4.chunk.js
  45.88 KB   build/static/css/1.a38ed525.chunk.css
  10.64 KB   build/static/css/main.c80691aa.chunk.css
  763 B      build/static/js/runtime~main.4a686d48.js

The bundle size is significantly larger than recommended.
Consider reducing it with code splitting: https://goo.gl/9VhYWB
You can also analyze the project dependencies: https://goo.gl/LeUzfb

The project was built assuming it is hosted at ./.
You can control this with the homepage field in your package.json.

The build folder is ready to be deployed.

Find out more about deployment here:

  https://bit.ly/CRA-deploy

Done in 73.76s.
 ~/repos/misc/jaeger/jaeger-ui/packages/jaeger-ui (sort-asset-manifest) $ cat build/asset-manifest.json 
{
  "main.css": "./static/css/main.c80691aa.chunk.css",
  "main.js": "./static/js/main.375d1bb4.chunk.js",
  "main.js.map": "./static/js/main.375d1bb4.chunk.js.map",
  "static/css/1.a38ed525.chunk.css": "./static/css/1.a38ed525.chunk.css",
  "static/js/1.591b087f.chunk.js": "./static/js/1.591b087f.chunk.js",
  "static/js/1.591b087f.chunk.js.map": "./static/js/1.591b087f.chunk.js.map",
  "runtime~main.js": "./static/js/runtime~main.4a686d48.js",
  "runtime~main.js.map": "./static/js/runtime~main.4a686d48.js.map",
  "static/media/jaeger-logo.svg": "./static/media/jaeger-logo.a7093b12.svg",
  "static/media/monitor.png": "./static/media/monitor.c9164c96.png",
  "static/css/1.a38ed525.chunk.css.map": "./static/css/1.a38ed525.chunk.css.map",
  "static/css/main.c80691aa.chunk.css.map": "./static/css/main.c80691aa.chunk.css.map",
  "index.html": "./index.html",
  "precache-manifest.354025eed03d63a1a55f874c4d415373.js": "./precache-manifest.354025eed03d63a1a55f874c4d415373.js",
  "service-worker.js": "./service-worker.js"
} 
```